### PR TITLE
Fix duplicate selectbox errors

### DIFF
--- a/components/class_reports.py
+++ b/components/class_reports.py
@@ -23,11 +23,11 @@ def render_class_reports():
     col1, col2 = st.columns(2)
     
     with col1:
-        selected_class = st.selectbox("Select Class", classes)
+        selected_class = st.selectbox("Select Class", classes, key="class_report_class_select")
     
     with col2:
         exam_options = ["All Exams"] + [f"{row['EXNM']} ({row['ExID']})" for _, row in exams_df.iterrows()]
-        selected_exam = st.selectbox("Select Exam", exam_options)
+        selected_exam = st.selectbox("Select Exam", exam_options, key="class_report_exam_select")
     
     # Extract exam ID
     exam_id = None

--- a/components/sidebar.py
+++ b/components/sidebar.py
@@ -8,7 +8,8 @@ def render_sidebar():
     # Navigation
     page = st.sidebar.selectbox(
         "Select Report Type",
-        ["🏠 Home", "👤 Student Reports", "🎓 Class Reports", "📈 Analytics", "Upload Results","⚙️ Settings"]
+        ["🏠 Home", "👤 Student Reports", "🎓 Class Reports", "📈 Analytics", "Upload Results","⚙️ Settings"],
+        key="sidebar_page_select"
     )
     
     # Database connection status
@@ -31,11 +32,11 @@ def render_sidebar():
     
     # Exam filter
     exam_options = ["All Exams"] + [f"{row['EXNM']} ({row['ExID']})" for _, row in exams_df.iterrows()]
-    selected_exam = st.sidebar.selectbox("Select Exam", exam_options)
+    selected_exam = st.sidebar.selectbox("Select Exam", exam_options, key="sidebar_exam_select")
     
     # Class filter
     class_options = ["All Classes"] + classes
-    selected_class = st.sidebar.selectbox("Select Class", class_options)
+    selected_class = st.sidebar.selectbox("Select Class", class_options, key="sidebar_class_select")
     
     # Extract exam ID
     exam_id = None


### PR DESCRIPTION
## Summary
- add unique keys to sidebar selectboxes
- add keys to class report selectors

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_684b4752f8c8832f842d37991cef35e6